### PR TITLE
Potential fix for code scanning alert no. 3: Log injection

### DIFF
--- a/src/components/websocket-client.tsx
+++ b/src/components/websocket-client.tsx
@@ -102,7 +102,9 @@ export function WebSocketClient({ onStockUpdate, onPerformanceUpdate, onOverview
               break
 
             default:
-              console.log('Unknown message type:', message.type)
+              // Remove newlines from message.type before logging to prevent log injection
+              const sanitizedType = String(message.type).replace(/[\r\n]+/g, "");
+              console.log('Unknown message type:', sanitizedType);
           }
         } catch (error) {
           console.error('Error parsing WebSocket message:', error)


### PR DESCRIPTION
Potential fix for [https://github.com/rajgurung/stock-intelligence-frontend/security/code-scanning/3](https://github.com/rajgurung/stock-intelligence-frontend/security/code-scanning/3)

To fix this issue, we should sanitize `message.type` before logging it, removing potentially dangerous characters that could allow log injection. Specifically, newlines (`\n`, `\r`) should be stripped from the value before logging, as these can break the structure of the log. To preserve debugging usefulness, we can still log the sanitized version and optionally surround user-provided values with delimiters to make clear what's user input.

We only need to change the use of `console.log('Unknown message type:', message.type)` at line 105, sanitizing `message.type` as shown in the examples above. No other occurrences of user-source data are logged unsanitized in the provided snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
